### PR TITLE
CLOUDSOPS-512: Update to latest SipUnit

### DIFF
--- a/mss-arquillian-docs/jdocbook-mobicents/pom.xml
+++ b/mss-arquillian-docs/jdocbook-mobicents/pom.xml
@@ -49,13 +49,13 @@
 					<dependency>
 						<groupId>org.mobicents.jdocbook</groupId>
 						<artifactId>telestax-xslt-ns</artifactId>
-						<version>1.2.0</version>
+						<version>1.5.0.FINAL</version>
 					</dependency>
 					<dependency>
 						<groupId>org.mobicents.jdocbook</groupId>
 						<artifactId>telestax-community-style</artifactId>
 						<type>jdocbook-style</type>
-						<version>1.2.0</version>
+						<version>1.5.0.FINAL</version>
 					</dependency>
 				</dependencies>
 				<configuration>

--- a/mss-arquillian-docs/jdocbook-telescale/pom.xml
+++ b/mss-arquillian-docs/jdocbook-telescale/pom.xml
@@ -49,13 +49,13 @@
 					<dependency>
 						<groupId>org.mobicents.jdocbook</groupId>
 						<artifactId>telestax-xslt-ns</artifactId>
-						<version>1.2.0</version>
+						<version>1.5.0.FINAL</version>
 					</dependency>
 					<dependency>
 						<groupId>org.mobicents.jdocbook</groupId>
 						<artifactId>telestax-community-style</artifactId>
 						<type>jdocbook-style</type>
-						<version>1.2.0</version>
+						<version>1.5.0.FINAL</version>
 					</dependency>
 				</dependencies>
 				<configuration>

--- a/mss-arquillian-utilities-extension/src/main/java/org/jboss/arquillian/container/mss/extension/SipStackTool.java
+++ b/mss-arquillian-utilities-extension/src/main/java/org/jboss/arquillian/container/mss/extension/SipStackTool.java
@@ -110,11 +110,6 @@ public class SipStackTool {
 					reentrantListener, additionalProperties);
 			sipStack = new SipStack(myTransport, Integer.valueOf(myPort), myProperties);
 			logger.info("SipStack - "+sipStackName+" - created!");
-
-			SipStack.setTraceEnabled(myProperties.getProperty("sipunit.trace")
-					.equalsIgnoreCase("true")
-					|| myProperties.getProperty("sipunit.trace")
-					.equalsIgnoreCase("on"));
 		}
 		catch (Exception ex)
 		{
@@ -140,11 +135,6 @@ public class SipStackTool {
 		{
 			sipStack = new SipStack(transport, Integer.valueOf(myPort), myProperties);
 			logger.info("SipStack - "+sipStackName+" - created!");
-
-			SipStack.setTraceEnabled(myProperties.getProperty("sipunit.trace")
-					.equalsIgnoreCase("true")
-					|| myProperties.getProperty("sipunit.trace")
-					.equalsIgnoreCase("on"));
 		}
 		catch (Exception ex)
 		{

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 		<version.shrinkwrap_tomcat>1.0.0</version.shrinkwrap_tomcat>
 		<version.shrinkwrap_restcomm>1.0.2</version.shrinkwrap_restcomm>
 
-		<version.sipunit>2.0.1</version.sipunit>
+		<version.sipunit>2.0.2</version.sipunit>
 
 		<version.jboss_spec>1.0.0.Final</version.jboss_spec>
 		<version.weld_servlet>1.1.2.Final</version.weld_servlet>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
 					<preparationGoals>clean install</preparationGoals>
 				</configuration>
 			</plugin>
-			<plugin>
+			<!--plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.6</version>
@@ -339,7 +339,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
This fixes https://github.com/RestComm/mss-arquillian/issues/3
And will fix testsuite for https://github.com/RestComm/Restcomm-Connect/pull/2404
Currently without SipUnit 2.0.2 being released, this PR build will fail